### PR TITLE
Update gof.ergmm.r

### DIFF
--- a/R/gof.ergmm.r
+++ b/R/gof.ergmm.r
@@ -43,6 +43,9 @@ gof.ergmm <- function (object, ..., nsim=100,
   obs.odeg<-pobs.odeg<-sim.odeg<-psim.odeg<-pval.odeg<-bds.odeg<-pval.odeg<-NULL
 
   n <- network.size(nw)
+  
+  # Remove simulation object to free up some memory & reduce the size of the gof object
+  rm(SimNetworkSeriesObj)
 
   # Calculate network statistics for the observed graph
   # Set up the output arrays of sim variables


### PR DESCRIPTION
Added a statement to remove the SimNetworkSeriesObj, which makes the final gof object smaller.  This is described in the statnet_help email: http://mailman13.u.washington.edu/pipermail/statnet_help/2014/001878.html.
